### PR TITLE
Remove public properties originated from Func<T> factories

### DIFF
--- a/src/DynamoDBGenerator.SourceGenerator/DynamoDBDMarshallerEntry.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/DynamoDBDMarshallerEntry.cs
@@ -16,8 +16,8 @@ public class DynamoDBDMarshallerEntry : IIncrementalGenerator
         var updateClassDeclarations = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 Constants.DynamoDBGenerator.DynamoDbDocumentPropertyFullname,
-                static (node, _) => node is ClassDeclarationSyntax,
-                static (context, _) => (ClassDeclarationSyntax)context.TargetNode
+                (n, _) => n is ClassDeclarationSyntax,
+                (c, _) => (ClassDeclarationSyntax)c.TargetNode
             );
 
         var compilationAndClasses = context.CompilationProvider.Combine(updateClassDeclarations.Collect());

--- a/src/DynamoDBGenerator.SourceGenerator/Generations/AttributeExpressionName.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Generations/AttributeExpressionName.cs
@@ -71,7 +71,7 @@ public static class AttributeExpressionName
         var dataMembers = fn(typeSymbol)
             .Select(x =>
             {
-                var typeIdentifier = DynamoDbMarshaller.TypeIdentifier(x.DataMember.Type);
+                var typeIdentifier = x.DataMember.Type.TypeIdentifier();
                 var nameRef = $"_{x.DataMember.Name}NameRef";
                 var attributeReference = TypeName(x.DataMember.Type);
                 var isUnknown = typeIdentifier is UnknownType;

--- a/src/DynamoDBGenerator.SourceGenerator/Generations/AttributeExpressionValue.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Generations/AttributeExpressionValue.cs
@@ -8,7 +8,7 @@ public static class AttributeExpressionValue
 {
 
     private static readonly Func<ITypeSymbol, string> GetAttributeValueInterfaceName = TypeExtensions.CacheFactory(SymbolEqualityComparer.IncludeNullability,
-        x => $"{Constants.DynamoDBGenerator.Marshaller.AttributeExpressionValueTrackerInterface}<{DynamoDbMarshaller.TypeName(x).annotated}>");
+        x => $"{Constants.DynamoDBGenerator.Marshaller.AttributeExpressionValueTrackerInterface}<{x.Representation().annotated}>");
 
     private static readonly Func<ITypeSymbol, string> TypeName = TypeExtensions.SuffixedTypeSymbolNameFactory("Values", SymbolEqualityComparer.Default);
 
@@ -70,7 +70,7 @@ public static class AttributeExpressionValue
         );
 
         foreach (var yield in
-                 $"IEnumerable<KeyValuePair<string, AttributeValue>> {interfaceName}.{Constants.DynamoDBGenerator.Marshaller.AttributeExpressionValueTrackerAccessedValues}({DynamoDbMarshaller.TypeName(typeSymbol).annotated} entity)"
+                 $"IEnumerable<KeyValuePair<string, AttributeValue>> {interfaceName}.{Constants.DynamoDBGenerator.Marshaller.AttributeExpressionValueTrackerAccessedValues}({typeSymbol.Representation().annotated} entity)"
                      .CreateBlock(yields))
             yield return yield;
 
@@ -89,7 +89,7 @@ public static class AttributeExpressionValue
         var dataMembers = fn(typeSymbol)
             .Select(x =>
             {
-                var typeIdentifier = DynamoDbMarshaller.TypeIdentifier(x.DataMember.Type);
+                var typeIdentifier = x.DataMember.Type.TypeIdentifier();
                 var valueRef = $"_{x.DataMember.Name}ValueRef";
                 var attributeReference = TypeName(x.DataMember.Type);
                 var isUnknown = typeIdentifier is UnknownType;

--- a/src/DynamoDBGenerator.SourceGenerator/Generations/KeyMarshaller.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Generations/KeyMarshaller.cs
@@ -15,7 +15,7 @@ public static class KeyMarshaller
     private static IEnumerable<string> CreateAssignment(string validateReference, string keyReference, DynamoDbDataMember dataMember)
     {
         const string reference = "value";
-        var expectedType = DynamoDbMarshaller.TypeName(dataMember.DataMember.Type).original;
+        var expectedType = dataMember.DataMember.Type.Representation().original;
         var expression = $"{keyReference} is {expectedType} {{ }} {reference}";
 
         var innerContent = $"if ({expression}) "


### PR DESCRIPTION
Remove `Func<T>`  used in DynamoDBMarshaller.cs 