### PR TITLE
Make EntityType optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ public class Person
 ```csharp
 // A typical scenario would be that you would use multuple DynamoDBMarshaller and describe your operaitons via PropertyName.
 // If you do not specify an ArgumentType it will use your main entity Type instead which is typically useful for PUT operations.
-[DynamoDBMarshaller(typeof(Person), ArgumentType = typeof((string PersonId, string Firstname)), PropertyName = "UpdateFirstName")]
+[DynamoDBMarshaller(EntityType = typeof(Person), ArgumentType = typeof((string PersonId, string Firstname)), PropertyName = "UpdateFirstName")]
 public partial class Repository { }
 
 internal static class Program
@@ -237,7 +237,7 @@ public class EntityDTO
     public string GlobalSecondaryIndexRangeKey { get; set; }
 }
 
-[DynamoDBMarshaller(typeof(EntityDTO))]
+[DynamoDBMarshaller(EntityType = typeof(EntityDTO))]
 public partial class Repository { }
 
 internal static class Program
@@ -292,7 +292,7 @@ public class MyCustomConverters : AttributeValueConverters
 }
 
 [DynamoDBMarshallerOptions(Converter = typeof(MyCustomConverters))]
-[DynamoDBMarshaller(typeof(Person), PropertyName = "PersonMarshaller")]
+[DynamoDBMarshaller(EntityType = typeof(Person), PropertyName = "PersonMarshaller")]
 public partial Repository 
 {
 
@@ -303,7 +303,7 @@ public partial Repository
 
 ```csharp
 [DynamoDBMarshallerOptions(EnumConversion = EnumConversion.Name)]
-[DynamoDBMarshaller(typeof(Person), PropertyName = "PersonMarshaller")]
+[DynamoDBMarshaller(EntityType = typeof(Person), PropertyName = "PersonMarshaller")]
 public partial class Repository { }
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ As part of the source generation process, two additional types will be mirrored 
 * A reference tracker that functions as attribute references for the arguments you provide to DynamoDB.
 
 These trackers enable you to consistently construct your AttributeExpressions using string interpolation. 
-
 For an illustrative example, refer to the [tests](https://github.com/inputfalken/DynamoDB.SourceGenerator/blob/main/tests/DynamoDBGenerator.SourceGenerator.Tests/Extensions/ToAttributeExpressionTests.cs).
 
 ## Nullable reference types
@@ -219,6 +218,7 @@ The source generator will internally validate your object arguments. So if you p
 
 ```csharp
 
+[DynamoDBMarshaller(PropertyName = 'KeyMarshallerSample')]
 public class EntityDTO
 {
     [DynamoDBHashKey("PK")]
@@ -237,21 +237,17 @@ public class EntityDTO
     public string GlobalSecondaryIndexRangeKey { get; set; }
 }
 
-[DynamoDBMarshaller(EntityType = typeof(EntityDTO))]
-public partial class Repository { }
-
 internal static class Program
 {
     public static void Main()
     {
-        var repository = new Repository();
         // PrimaryKeyMarshaller is used to convert the keys obtained from the [DynamoDBHashKey] and [DynamoDBRangeKey] attributes.
-        var keyMarshaller = repository.PrimaryKeyMarshaller;
+        var keyMarshaller = EntityDTO.KeyMarshallerSample.PrimaryKeyMarshaller;
 
         // IndexKeyMarshaller requires an argument that is the index name so it can provide you with the correct conversion based on the indexes you may have.
         // It works the same way for both LocalSecondaryIndex and GlobalSecondaryIndex attributes.
-        var GSIKeyMarshaller = repository.IndexKeyMarshaller("GSI");
-        var LSIKeyMarshaller = repository.IndexKeyMarshaller("LSI");
+        var GSIKeyMarshaller = EntityDTO.KeyMarshallerSample.IndexKeyMarshaller("GSI");
+        var LSIKeyMarshaller = EntityDTO.KeyMarshallerSample.IndexKeyMarshaller("LSI");
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project has not been tested in any real scenario and currently serves as a 
 
 ## Installation
 
-If you want access to a more high level abstraction of this functionality check out [Dynatello!](https://github.com/inputfalken/Dynatello)
+If you want access to a more high level abstraction utilizing builder patterns from the functionality of this library, check out [Dynatello!](https://github.com/inputfalken/Dynatello)
 
 ---
 
@@ -111,7 +111,7 @@ As part of the source generation process, two additional types will be mirrored 
 * A reference tracker that functions as attribute references for the arguments you provide to DynamoDB.
 
 These trackers enable you to consistently construct your AttributeExpressions using string interpolation. 
-For an illustrative example, refer to the [tests](https://github.com/inputfalken/DynamoDB.SourceGenerator/blob/main/tests/DynamoDBGenerator.SourceGenerator.Tests/Extensions/ToAttributeExpressionTests.cs).
+For an illustrative example, refer to the [tests](tests/DynamoDBGenerator.SourceGenerator.Tests/Extensions/ToAttributeExpressionTests.cs).
 
 ## Nullable reference types
 
@@ -236,7 +236,6 @@ public class EntityDTO
     [DynamoDBGlobalSecondaryIndexRangeKey("GSI")]
     public string GlobalSecondaryIndexRangeKey { get; set; }
 }
-
 internal static class Program
 {
     public static void Main()
@@ -305,5 +304,5 @@ public partial class Repository { }
 
 ## Project structure
 
-The `DynamoDBGenerator.SourceGenerator` assembly is responsible for doing the heavy lifting by generating the building
-blocks for the `DynamoDBGenerator` assembly to extend with convenient functionality.
+The `DynamoDBGenerator` assembly contains functionality that the `DynamoDBGenerator.SourceGenerator` rely on such as the [attribute](src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs) that will trigger the source generation.
+In other words both assemblies needs to be installed in order for the source generator to work as expected.

--- a/src/DynamoDBGenerator.SourceGenerator/Constants.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Constants.cs
@@ -12,7 +12,7 @@ public static class Constants
 
             public static class DynamoDBMarshallerArgument
             {
-
+                public const string EntityType = "EntityType";
                 public const string PropertyName = "PropertyName";
                 public const string ArgumentType = "ArgumentType";
             }

--- a/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
+++ b/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
@@ -8,7 +8,7 @@ namespace DynamoDBGenerator.Attributes;
 /// <example>
 ///     The example below demonstrates the usage of this attribute in a repository class:
 ///     <code>
-///         [DynamoDBMarshaller(typeof(OrderEntity), PropertyName = "MyCustomPropertyName")]
+///         [DynamoDBMarshaller(EntityType = typeof(OrderEntity), PropertyName = "MyCustomPropertyName"))]
 ///         public class Repository
 ///         {
 ///             public Repository()
@@ -27,17 +27,10 @@ namespace DynamoDBGenerator.Attributes;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true)]
 public class DynamoDBMarshallerAttribute : Attribute
 {
-    // ReSharper disable once NotAccessedField.Local
-    private readonly Type _entityType;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="DynamoDBMarshallerAttribute"/> class.
+    /// Gets or sets the type that will be used for marshalling and unmarshalling.
     /// </summary>
-    /// <param name="entityType">The type to be represented as a DynamoDB entity.</param>
-    public DynamoDBMarshallerAttribute(Type entityType)
-    {
-        _entityType = entityType;
-    }
+    public Type? EntityType { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the property to use when accessing the marshaller.
@@ -49,5 +42,5 @@ public class DynamoDBMarshallerAttribute : Attribute
     /// will use as its argument type-parameter.
     /// </summary>
     public Type? ArgumentType { get; set; }
-    
+
 }

--- a/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
+++ b/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
@@ -30,17 +30,26 @@ public class DynamoDBMarshallerAttribute : Attribute
     /// <summary>
     /// Gets or sets the type that will be used for marshalling and unmarshalling.
     /// </summary>
+    /// <remarks>
+    /// The default value will be the type where the attribute was applied to.
+    /// </remarks>
     public Type? EntityType { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the property to use when accessing the marshaller.
     /// </summary>
+    /// <remarks>
+    /// The default value will be dependant on the <see cref="EntityType"/> by having the naming format of `{Type.Name}Marshaller`.
+    /// </remarks>
     public string? PropertyName { get; set; }
 
     /// <summary>
     /// Gets or sets the type that <see cref="IDynamoDBMarshaller{TEntity,TArg,TEntityAttributeNameTracker,TArgumentAttributeValueTracker}"/>
     /// will use as its argument type-parameter.
     /// </summary>
+    /// <remarks>
+    /// The default value will be <see cref="EntityType"/>, this is will make the the generated code be implemented in a PUT oriented manner.
+    /// </remarks>
     public Type? ArgumentType { get; set; }
 
 }

--- a/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
+++ b/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
@@ -2,20 +2,28 @@ using System;
 namespace DynamoDBGenerator.Attributes;
 
 /// <summary>
-/// Attribute to generate an implementation of <see cref="IDynamoDBMarshaller{TEntity,TArg,TEntityAttributeNameTracker,TArgumentAttributeValueTracker}" />
-/// for the specified type.
+/// Attribute used to source generate an implementation of <see cref="IDynamoDBMarshaller{TEntity,TArg,TEntityAttributeNameTracker,TArgumentAttributeValueTracker}" />.
 /// </summary>
 /// <example>
-///     The example below demonstrates the usage of this attribute in a repository class:
+///     The example below demonstrates a console app where this attribute is used:
 ///     <code>
-///         [DynamoDBMarshaller(EntityType = typeof(OrderEntity), PropertyName = "MyCustomPropertyName"))]
-///         public class Repository
+///         public class Program
 ///         {
-///             public Repository()
+///             public static void Main(string[] args)
 ///             {
-///                 var orderMarshaller = MyCustomPropertyName;
+///                 var orderEntity = new OrderEntity 
+///                                    {
+///                                        Id = "1",
+///                                        Cost = 2.3
+///                                    };
+///                 var attributeValues  = OrderEntity.MyCustomPropertyName.Marshall(orderEntity);
+///                 foreach(var keyValue in attributeValues)
+///                 {
+///                     Console.WriteLine(attributeValues);
+///                 }
 ///             }
 ///         }
+///         [DynamoDBMarshaller(EntityType = typeof(OrderEntity), PropertyName = "MyCustomPropertyName"))]
 ///         public class OrderEntity
 ///         {
 ///             [DynamoDBHashKey]
@@ -39,7 +47,7 @@ public class DynamoDBMarshallerAttribute : Attribute
     /// Gets or sets the name of the property to use when accessing the marshaller.
     /// </summary>
     /// <remarks>
-    /// The default value will be dependant on the <see cref="EntityType"/> by having the naming format of `{Type.Name}Marshaller`.
+    /// The default value will be dependant on the <see cref="EntityType"/> by having the naming format of `{Type.Name}Marshaller` but without the reflection.
     /// </remarks>
     public string? PropertyName { get; set; }
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Benchmarks/Models/PersonEntity.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Benchmarks/Models/PersonEntity.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Benchmarks.Models;
 
 
-[DynamoDBMarshaller(typeof(PersonEntity))]
+[DynamoDBMarshaller(EntityType = typeof(PersonEntity))]
 public partial class PersonEntity
 {
     [DynamoDBHashKey]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/CustomObjects/ChildClassTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/CustomObjects/ChildClassTests.cs
@@ -2,7 +2,7 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.CustomObjects;
 
-[DynamoDBMarshaller(typeof(ParentClass))]
+[DynamoDBMarshaller(EntityType = typeof(ParentClass))]
 public partial class ChildClassTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/CustomObjects/SiblingClasstests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/CustomObjects/SiblingClasstests.cs
@@ -2,7 +2,7 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.CustomObjects;
 
-[DynamoDBMarshaller(typeof(SiblingClassOne))]
+[DynamoDBMarshaller(EntityType = typeof(SiblingClassOne))]
 public partial class SiblingClassTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/DictionaryTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/DictionaryTests.cs
@@ -2,7 +2,7 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.Generics;
 
-[DynamoDBMarshaller(typeof(DictionaryClass))]
+[DynamoDBMarshaller(EntityType = typeof(DictionaryClass))]
 public partial class DictionaryTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/KeyValueCollectionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/KeyValueCollectionTests.cs
@@ -2,7 +2,7 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.Generics;
 
-[DynamoDBMarshaller(typeof(KeyValueCollectionClass))]
+[DynamoDBMarshaller(EntityType = typeof(KeyValueCollectionClass))]
 public partial class KeyValueCollectionTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/LookUpTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/LookUpTests.cs
@@ -2,7 +2,7 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.Generics;
 
-[DynamoDBMarshaller(typeof(LookUpClass))]
+[DynamoDBMarshaller(EntityType = typeof(LookUpClass))]
 public partial class LookUpTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/NullableTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/NullableTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Exceptions;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.Generics;
 
-[DynamoDBMarshaller(typeof(OptionalIntegerClass))]
+[DynamoDBMarshaller(EntityType = typeof(OptionalIntegerClass))]
 public partial class NullableTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/StringCollectionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/StringCollectionTests.cs
@@ -2,7 +2,7 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.Generics;
 
-[DynamoDBMarshaller(typeof(StringedCollectionClass))]
+[DynamoDBMarshaller(EntityType = typeof(StringedCollectionClass))]
 public partial class StringCollectionTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/TupleTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/TupleTests.cs
@@ -2,10 +2,10 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.Generics;
 
-[DynamoDBMarshaller(typeof(TupleClass))]
-[DynamoDBMarshaller(typeof((int X, int Y)), PropertyName = "XAndYTuple")]
-[DynamoDBMarshaller(typeof((int, int )), PropertyName = "UnnamedTuple")]
-[DynamoDBMarshaller(typeof((string Id, (int X, int Y) Coordinates)), PropertyName = "NestedXAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof(TupleClass))]
+[DynamoDBMarshaller(EntityType = typeof((int X, int Y)), PropertyName = "XAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof((int, int )), PropertyName = "UnnamedTuple")]
+[DynamoDBMarshaller(EntityType = typeof((string Id, (int X, int Y) Coordinates)), PropertyName = "NestedXAndYTuple")]
 public partial class TupleTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/InheritenceTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/InheritenceTests.cs
@@ -3,7 +3,7 @@ using AutoFixture;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize;
 
-[DynamoDBMarshaller(typeof(Cat))]
+[DynamoDBMarshaller(EntityType = typeof(Cat))]
 public partial class InheritanceTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/InitializationTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/InitializationTests.cs
@@ -2,15 +2,15 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize;
 
-[DynamoDBMarshaller(typeof(ConstructorOnlyClass))]
-[DynamoDBMarshaller(typeof(ObjectInitializerOnlyClass))]
-[DynamoDBMarshaller(typeof(ObjectInitializerMixedWithConstructorClass))]
-[DynamoDBMarshaller(typeof(ConstructorClassWithMixedName))]
-[DynamoDBMarshaller(typeof(InlinedRecord))]
-[DynamoDBMarshaller(typeof(ExplicitConstructorRecord))]
-[DynamoDBMarshaller(typeof(InlineRecordWithNestedRecord))]
-[DynamoDBMarshaller(typeof(ClassWithConstructorThatObjectInitializerShouldOnlyBeUsed), PropertyName = "InitializerOnly")]
-[DynamoDBMarshaller(typeof(ClassWithConstructorThatShouldOnlyBeUsed), PropertyName = "ConstructorOnly")]
+[DynamoDBMarshaller(EntityType = typeof(ConstructorOnlyClass))]
+[DynamoDBMarshaller(EntityType = typeof(ObjectInitializerOnlyClass))]
+[DynamoDBMarshaller(EntityType = typeof(ObjectInitializerMixedWithConstructorClass))]
+[DynamoDBMarshaller(EntityType = typeof(ConstructorClassWithMixedName))]
+[DynamoDBMarshaller(EntityType = typeof(InlinedRecord))]
+[DynamoDBMarshaller(EntityType = typeof(ExplicitConstructorRecord))]
+[DynamoDBMarshaller(EntityType = typeof(InlineRecordWithNestedRecord))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithConstructorThatObjectInitializerShouldOnlyBeUsed), PropertyName = "InitializerOnly")]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithConstructorThatShouldOnlyBeUsed), PropertyName = "ConstructorOnly")]
 public partial class InitializationTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/MissingValueTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/MissingValueTests.cs
@@ -3,9 +3,9 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Exceptions;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize;
 
-[DynamoDBMarshaller(typeof(RequiredReferenceTypeValueMissingClass))]
-[DynamoDBMarshaller(typeof(OptionalReferenceTypeValueMissingClass))]
-[DynamoDBMarshaller(typeof(RequiredValueTypeValueMissingClass))]
+[DynamoDBMarshaller(EntityType = typeof(RequiredReferenceTypeValueMissingClass))]
+[DynamoDBMarshaller(EntityType = typeof(OptionalReferenceTypeValueMissingClass))]
+[DynamoDBMarshaller(EntityType = typeof(RequiredValueTypeValueMissingClass))]
 public partial class MissingValueTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/PropertyRenamingTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/PropertyRenamingTests.cs
@@ -2,7 +2,7 @@ using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize;
 
-[DynamoDBMarshaller(typeof(PropertyWithMixedNames))]
+[DynamoDBMarshaller(EntityType = typeof(PropertyWithMixedNames))]
 public partial class PropertyRenamingTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/DynamoDBGsiKeyMarshallerTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/DynamoDBGsiKeyMarshallerTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(typeof(GsiHashAndRangeKey))]
+[DynamoDBMarshaller(EntityType = typeof(GsiHashAndRangeKey))]
 public partial class DynamoDBGsiKeyMarshallerTests
 {
     [Fact(Skip = "Could be nice to validate this before the marshaller is created.")]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/DynamoDBIndexTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/DynamoDBIndexTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(typeof(ReverseAccessIndexSetup))]
+[DynamoDBMarshaller(EntityType = typeof(ReverseAccessIndexSetup))]
 public partial class DynamoDBIndexTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/DynamoDBLsiKeyMarshallerTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/DynamoDBLsiKeyMarshallerTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(typeof(LsiHashAndRangeKey))]
+[DynamoDBMarshaller(EntityType = typeof(LsiHashAndRangeKey))]
 public partial class DynamoDBLsiKeyMarshallerTests
 {
     [Fact(Skip = "Could be nice to validate this before the marshaller is created.")]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/ExpressionAttributeTrackerTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/ExpressionAttributeTrackerTests.cs
@@ -1,11 +1,11 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(typeof(Person), ArgumentType = typeof((string firstName, DateTime timeStamp)), PropertyName = "PersonWithTupleArgument")]
-[DynamoDBMarshaller(typeof(Person))]
-[DynamoDBMarshaller(typeof(SelfReferencingClass))]
-[DynamoDBMarshaller(typeof(ClassWithOverriddenAttributeName))]
-[DynamoDBMarshaller(typeof(InheritedClass))]
+[DynamoDBMarshaller(EntityType = typeof(Person), ArgumentType = typeof((string firstName, DateTime timeStamp)), PropertyName = "PersonWithTupleArgument")]
+[DynamoDBMarshaller(EntityType = typeof(Person))]
+[DynamoDBMarshaller(EntityType = typeof(SelfReferencingClass))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithOverriddenAttributeName))]
+[DynamoDBMarshaller(EntityType = typeof(InheritedClass))]
 public partial class ExpressionAttributeTrackerTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/AddCustomConverterTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/AddCustomConverterTests.cs
@@ -7,7 +7,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.ConverterTests;
 
 [DynamoDbMarshallerOptions(Converters = typeof(Converter))]
-[DynamoDBMarshaller(typeof(Container<Money>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<Money>))]
 public partial class AddCustomConverterTests : RecordMarshalAsserter<AddCustomConverterTests.Money>
 {
     

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/AddCustomConverterWithParamTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/AddCustomConverterWithParamTests.cs
@@ -7,7 +7,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.ConverterTests;
 
 [DynamoDbMarshallerOptions(Converters = typeof(Converter))]
-[DynamoDBMarshaller(typeof(Container<Money>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<Money>))]
 public partial class AddCustomConverterWithParamTests : RecordMarshalAsserter<AddCustomConverterWithParamTests.Money>
 {
     

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/OverrideDefaultConverterTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/OverrideDefaultConverterTests.cs
@@ -7,7 +7,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.ConverterTests;
 
 [DynamoDbMarshallerOptions(Converters = typeof(Converters))]
-[DynamoDBMarshaller(typeof(Container<DateTime>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateTime>))]
 public partial class OverrideDefaultConverterTests : RecordMarshalAsserter<DateTime>
 {
     public OverrideDefaultConverterTests() :

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/OverrideDefaultConverterWithParamTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/ConverterTests/OverrideDefaultConverterWithParamTests.cs
@@ -7,7 +7,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.ConverterTests;
 
 [DynamoDbMarshallerOptions(Converters = typeof(Converters))]
-[DynamoDBMarshaller(typeof(Container<DateTime>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateTime>))]
 public partial class OverrideDefaultConverterWithParamTests : RecordMarshalAsserter<DateTime>
 {
     public OverrideDefaultConverterWithParamTests() :

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/ArrayTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/ArrayTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections;
 
-[DynamoDBMarshaller(typeof(Container<string[]>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<string[]>))]
 // ReSharper disable once UnusedType.Global
 public partial class NoneNullableArrayElementTests : NoneNullableElementAsserter<string[], string>
 {
@@ -22,7 +22,7 @@ public partial class NoneNullableArrayElementTests : NoneNullableElementAsserter
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<string?[]>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<string?[]>))]
 // ReSharper disable once UnusedType.Global
 public partial class NullableArrayElementTests : NullableElementAsserter<string?[], string?>
 {

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/EnumerableTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/EnumerableTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections;
 
-[DynamoDBMarshaller(typeof(Container<IEnumerable<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IEnumerable<string>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NoneNullableEnumerableElementTests : NoneNullableElementAsserter<IEnumerable<string>, string>
 {
@@ -33,7 +33,7 @@ public partial class NoneNullableEnumerableElementTests : NoneNullableElementAss
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<IEnumerable<string?>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IEnumerable<string?>>))]
 public partial class NullableEnumerableElementTests : NullableElementAsserter<IEnumerable<string?>, string?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/ICollectionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/ICollectionTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections;
 
-[DynamoDBMarshaller(typeof(Container<ICollection<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ICollection<string>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NoneNullableICollectionElementTests : NoneNullableElementAsserter<ICollection<string>, string>
 {
@@ -28,7 +28,7 @@ public partial class NoneNullableICollectionElementTests : NoneNullableElementAs
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<ICollection<string?>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ICollection<string?>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NullableICollectionElementTests : NullableElementAsserter<ICollection<string?>, string?>
 {

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/IListTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/IListTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections;
 
-[DynamoDBMarshaller(typeof(Container<IList<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IList<string>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NoneNullableIListElementTests : NoneNullableElementAsserter<IList<string>, string>
 {
@@ -27,7 +27,7 @@ public partial class NoneNullableIListElementTests : NoneNullableElementAsserter
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<IList<string?>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IList<string?>>))]
 public partial class NullableIListElementTests : NullableElementAsserter<IList<string?>, string?>
 {
     public NullableIListElementTests() : base(Strings(), x => x.ToList())

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/IReadOnlyCollectionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/IReadOnlyCollectionTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections;
 
-[DynamoDBMarshaller(typeof(Container<IReadOnlyCollection<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IReadOnlyCollection<string>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NoneNullableIReadOnlyCollectionElementTests : NoneNullableElementAsserter<IReadOnlyCollection<string>, string>
 {
@@ -27,7 +27,7 @@ public partial class NoneNullableIReadOnlyCollectionElementTests : NoneNullableE
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<IReadOnlyCollection<string?>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IReadOnlyCollection<string?>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NullableIReadOnlyCollectionElementTests : NullableElementAsserter<IReadOnlyCollection<string?>, string?>
 {

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/IReadOnlyListTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/IReadOnlyListTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections;
 
-[DynamoDBMarshaller(typeof(Container<IReadOnlyList<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IReadOnlyList<string>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NoneNullableIReadOnlyListElementTests : NoneNullableElementAsserter<IReadOnlyList<string>, string>
 {
@@ -27,7 +27,7 @@ public partial class NoneNullableIReadOnlyListElementTests : NoneNullableElement
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<IReadOnlyList<string?>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IReadOnlyList<string?>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NullableIReadOnlyListElementTests : NullableElementAsserter<IReadOnlyList<string?>, string?>
 {

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/ListTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Collections/ListTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Collections;
 
-[DynamoDBMarshaller(typeof(Container<List<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<List<string>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NoneNullableListElementTests : NoneNullableElementAsserter<List<string>, string>
 {
@@ -21,7 +21,7 @@ public partial class NoneNullableListElementTests : NoneNullableElementAsserter<
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<List<string?>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<List<string?>>))]
 // ReSharper disable once UnusedType.Global
 public partial class NullableListElementTests : NullableElementAsserter<List<string?>, string?>
 {

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Dictionaries/DictionaryTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Dictionaries/DictionaryTests.cs
@@ -5,7 +5,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.G
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Dictionaries;
 
-[DynamoDBMarshaller(typeof(Container<Dictionary<string, Entity>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<Dictionary<string, Entity>>))]
 public partial class DictionaryTests : RecordMarshalAsserter<Dictionary<string, DictionaryTests.Entity>>
 {
     private const string Element1 = "hello";
@@ -54,7 +54,7 @@ public partial class DictionaryTests : RecordMarshalAsserter<Dictionary<string, 
     public record Entity(string Foo, string Bar);
 }
 
-//[DynamoDBMarshaller(typeof(Container<Dictionary<string, Entity?>>))]
+//[DynamoDBMarshaller(EntityType = typeof(Container<Dictionary<string, Entity?>>))]
 //public partial class
 //    NullableDictionaryElementsTests : RecordMarshalAsserter<Dictionary<string, NullableDictionaryElementsTests.Entity?>>
 //{

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Lookups/LookupTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Lookups/LookupTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Lookups;
 
-[DynamoDBMarshaller(typeof(Container<ILookup<string, Entity>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ILookup<string, Entity>>))]
 public partial class ILookupTests : RecordMarshalAsserter<ILookup<string, ILookupTests.Entity>>
 {
     public record Entity(string Foo, string Bar);
@@ -67,7 +67,7 @@ public partial class ILookupTests : RecordMarshalAsserter<ILookup<string, ILooku
     }
 }
 
-//[DynamoDBMarshaller(typeof(Container<ILookup<string, Entity?>>))]
+//[DynamoDBMarshaller(EntityType = typeof(Container<ILookup<string, Entity?>>))]
 //public partial class
 //    NullableILookupElementsTests : RecordMarshalAsserter<ILookup<string, NullableILookupElementsTests.Entity?>>
 //{

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/HashSetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/HashSetTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
-[DynamoDBMarshaller(typeof(Container<HashSet<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<HashSet<string>>))]
 public partial class HashSetTests : NoneNullableElementAsserter<HashSet<string>, string>
 {
     public HashSetTests() : base(Strings(), x => new HashSet<string>(x))

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IReadOnlySetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IReadOnlySetTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
-[DynamoDBMarshaller(typeof(Container<IReadOnlySet<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<IReadOnlySet<string>>))]
 public partial class IReadOnlySetTests : NoneNullableElementAsserter<IReadOnlySet<string>, string>
 {
     public IReadOnlySetTests() : base(Strings(),x => new SortedSet<string>(x))

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/ISetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/ISetTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
-[DynamoDBMarshaller(typeof(Container<ISet<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ISet<string>>))]
 public partial class ISetTests : NoneNullableElementAsserter<ISet<string>, string>
 {
     public ISetTests() : base(Strings(), x => new HashSet<string>(x))

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IntHashSetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IntHashSetTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
-[DynamoDBMarshaller(typeof(Container<HashSet<int>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<HashSet<int>>))]
 public partial class IntHashSetTests : SetAsserter<HashSet<int>, int>
 {
 
@@ -21,7 +21,7 @@ public partial class IntHashSetTests : SetAsserter<HashSet<int>, int>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<HashSet<decimal>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<HashSet<decimal>>))]
 public partial class DecimalHashSetTests : SetAsserter<HashSet<decimal>, decimal>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/SortedSetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/SortedSetTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
-[DynamoDBMarshaller(typeof(Container<SortedSet<string>>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<SortedSet<string>>))]
 public partial class SortedSetTests : NoneNullableElementAsserter<SortedSet<string>, string>
 {
     public SortedSetTests() : base(Strings(), x => new SortedSet<string>(x))

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/ComplexTupleTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/ComplexTupleTests.cs
@@ -6,7 +6,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Tuples;
 
-[DynamoDBMarshaller(typeof((string FirstName, int Age, IReadOnlyCollection<((string Address, string? ZipCode) Address, (string Email, string Phone)? Mediums)> PhoneAndEmail )))]
+[DynamoDBMarshaller(EntityType = typeof((string FirstName, int Age, IReadOnlyCollection<((string Address, string? ZipCode) Address, (string Email, string Phone)? Mediums)> PhoneAndEmail )))]
 public partial class ComplexTupleTests : MarshalAsserter<(string FirstName, int Age,
     IReadOnlyCollection<((string Address, string? ZipCode) Address, (string Email, string Phone)? Mediums)> PhoneAndEmail)>
 {

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/SimpleTupleTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/SimpleTupleTests.cs
@@ -5,7 +5,7 @@ using DynamoDBGenerator.Exceptions;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Tuples;
 
-[DynamoDBMarshaller(typeof((string FirstName, string LastName, string? EmailAddress)))]
+[DynamoDBMarshaller(EntityType = typeof((string FirstName, string LastName, string? EmailAddress)))]
 public partial class SimpleTupleTests : MarshalAsserter<(string FirstName, string LastName, string? EmailAddress)>
 {
     private static readonly Fixture Fixture = new();

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/TupleArgumentTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/TupleArgumentTests.cs
@@ -4,8 +4,8 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Extensions;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Tuples;
 
-[DynamoDBMarshaller(typeof(Animal), ArgumentType = typeof((string Id, Animal.Status Status, DateTime TimeStamp)), PropertyName = "SetStatus")]
-[DynamoDBMarshaller(typeof(Animal), PropertyName = "SaveAnimal", ArgumentType = typeof((Animal animal, Animal.Status adopted, Animal.Status pending)))]
+[DynamoDBMarshaller(EntityType = typeof(Animal), ArgumentType = typeof((string Id, Animal.Status Status, DateTime TimeStamp)), PropertyName = "SetStatus")]
+[DynamoDBMarshaller(EntityType = typeof(Animal), PropertyName = "SaveAnimal", ArgumentType = typeof((Animal animal, Animal.Status adopted, Animal.Status pending)))]
 public partial class TupleArgumentTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/BoolTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/BoolTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<bool>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<bool>))]
 public partial class BoolTests : RecordMarshalAsserter<bool>
 {
     public BoolTests() : base(new[] {true, false}, x => new AttributeValue {BOOL = x})
@@ -19,7 +19,7 @@ public partial class BoolTests : RecordMarshalAsserter<bool>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<bool?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<bool?>))]
 public partial class NullableBoolTests : RecordMarshalAsserter<bool?>
 {
     public NullableBoolTests() : base(new[] {true, false}.Cast<bool?>().Append(null), x => x is null ? null : new AttributeValue {BOOL = x.Value})

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/ByteTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/ByteTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<byte>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<byte>))]
 public partial class ByteTests : RecordMarshalAsserter<byte>
 {
 
@@ -20,7 +20,7 @@ public partial class ByteTests : RecordMarshalAsserter<byte>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<byte?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<byte?>))]
 public partial class NullableByteTests : RecordMarshalAsserter<byte?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/CharTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/CharTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.Exceptions;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<char>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<char>))]
 public partial class CharTests : RecordMarshalAsserter<char>
 {
 
@@ -30,7 +30,7 @@ public partial class CharTests : RecordMarshalAsserter<char>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<char?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<char?>))]
 public partial class NullableCharTests : RecordMarshalAsserter<char?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DateOnlyTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DateOnlyTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<DateOnly>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateOnly>))]
 public partial class DateOnlyTests : RecordMarshalAsserter<DateOnly>
 {
 
@@ -21,7 +21,7 @@ public partial class DateOnlyTests : RecordMarshalAsserter<DateOnly>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<DateOnly?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateOnly?>))]
 public partial class NullableDateOnlyTests : RecordMarshalAsserter<DateOnly?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DateTimeOffsetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DateTimeOffsetTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<DateTimeOffset>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateTimeOffset>))]
 public partial class DateTimeOffsetTests : RecordMarshalAsserter<DateTimeOffset>
 {
 
@@ -21,7 +21,7 @@ public partial class DateTimeOffsetTests : RecordMarshalAsserter<DateTimeOffset>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<DateTimeOffset?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateTimeOffset?>))]
 public partial class NullableDateTimeOffsetTests : RecordMarshalAsserter<DateTimeOffset?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DateTimeTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DateTimeTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<DateTime>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateTime>))]
 public partial class DateTimeTests : RecordMarshalAsserter<DateTime>
 {
 
@@ -21,7 +21,7 @@ public partial class DateTimeTests : RecordMarshalAsserter<DateTime>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<DateTime?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DateTime?>))]
 public partial class NullableDateTimeTests : RecordMarshalAsserter<DateTime?>
 {
     protected override Container<DateTime?> UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DecimalTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DecimalTests.cs
@@ -6,7 +6,7 @@ namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshall
 
 
 
-[DynamoDBMarshaller(typeof(Container<decimal>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<decimal>))]
 public partial class DecimalTests : RecordMarshalAsserter<decimal>
 {
     public DecimalTests() : base(new[] {30.32093290329m}, x => new() {N = x.ToString(CultureInfo.InvariantCulture)})
@@ -24,7 +24,7 @@ public partial class DecimalTests : RecordMarshalAsserter<decimal>
 
 }
 
-[DynamoDBMarshaller(typeof(Container<decimal?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<decimal?>))]
 public partial class NullableDecimalTests : RecordMarshalAsserter<decimal?>
 {
     public NullableDecimalTests() : base(new decimal?[] {null, 30.32093290329m}, x => x is null ? null : new AttributeValue {N = x.Value.ToString(CultureInfo.InvariantCulture)})

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DoubleTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/DoubleTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<double>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<double>))]
 public partial class DoubleTests : RecordMarshalAsserter<double>
 {
     public DoubleTests() : base(new[] {30.9328932, 30.9328933}, x => new() {N = x.ToString(CultureInfo.InvariantCulture)})
@@ -20,7 +20,7 @@ public partial class DoubleTests : RecordMarshalAsserter<double>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<double?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<double?>))]
 public partial class NullableDoubleTests : RecordMarshalAsserter<double?>
 {
     public NullableDoubleTests() : base(new double?[] {null, 30.9328933}, x => x is null ? null : new AttributeValue {N = x.Value.ToString(CultureInfo.InvariantCulture)})

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/EnumTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/EnumTests.cs
@@ -6,7 +6,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.Name)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek>))]
 public partial class StringEnumTests : RecordMarshalAsserter<DayOfWeek>
 {
     public StringEnumTests() : base(new[] { DayOfWeek.Monday, DayOfWeek.Friday },
@@ -26,7 +26,7 @@ public partial class StringEnumTests : RecordMarshalAsserter<DayOfWeek>
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.Name)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek?>))]
 public partial class NullableStringEnumTests : RecordMarshalAsserter<DayOfWeek?>
 {
     public NullableStringEnumTests() : base(new DayOfWeek?[] { DayOfWeek.Monday, DayOfWeek.Friday, null },
@@ -47,7 +47,7 @@ public partial class NullableStringEnumTests : RecordMarshalAsserter<DayOfWeek?>
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.CaseInsensitiveName)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek>))]
 public partial class StringCIEnumTests : RecordMarshalAsserter<DayOfWeek>
 {
     public StringCIEnumTests() : base(new[] { DayOfWeek.Monday, DayOfWeek.Friday },
@@ -81,7 +81,7 @@ public partial class StringCIEnumTests : RecordMarshalAsserter<DayOfWeek>
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.CaseInsensitiveName)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek?>))]
 public partial class NullableStringCIEnumTests : RecordMarshalAsserter<DayOfWeek?>
 {
     public NullableStringCIEnumTests() : base(new DayOfWeek?[] { DayOfWeek.Monday, DayOfWeek.Friday, null },
@@ -116,7 +116,7 @@ public partial class NullableStringCIEnumTests : RecordMarshalAsserter<DayOfWeek
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.Integer)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek>))]
 public partial class IntEnumTests : RecordMarshalAsserter<DayOfWeek>
 {
     public IntEnumTests() : base(Enum.GetValues<DayOfWeek>(), x => new AttributeValue { N = ((int)x).ToString() })
@@ -135,7 +135,7 @@ public partial class IntEnumTests : RecordMarshalAsserter<DayOfWeek>
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.Integer)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek?>))]
 public partial class NullableIntEnumTests : RecordMarshalAsserter<DayOfWeek?>
 {
     public NullableIntEnumTests() : base(Enum.GetValues<DayOfWeek>().Cast<DayOfWeek?>().Append(null),
@@ -155,7 +155,7 @@ public partial class NullableIntEnumTests : RecordMarshalAsserter<DayOfWeek?>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<DayOfWeek>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek>))]
 public partial class DefaultEnumTests : RecordMarshalAsserter<DayOfWeek>
 {
     public DefaultEnumTests() : base(Enum.GetValues<DayOfWeek>(), x => new AttributeValue { N = ((int)x).ToString() })
@@ -173,7 +173,7 @@ public partial class DefaultEnumTests : RecordMarshalAsserter<DayOfWeek>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<DayOfWeek?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek?>))]
 public partial class DefaultNullableEnumTests : RecordMarshalAsserter<DayOfWeek?>
 {
     public DefaultNullableEnumTests() : base(Enum.GetValues<DayOfWeek>().Cast<DayOfWeek?>().Append(null),
@@ -194,7 +194,7 @@ public partial class DefaultNullableEnumTests : RecordMarshalAsserter<DayOfWeek?
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.UpperCaseName)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek>))]
 public partial class UpperCaseEnumTests : RecordMarshalAsserter<DayOfWeek>
 {
     public UpperCaseEnumTests() : base(Enum.GetValues<DayOfWeek>(), x =>  new AttributeValue { S = x.ToString().ToUpperInvariant() })
@@ -214,7 +214,7 @@ public partial class UpperCaseEnumTests : RecordMarshalAsserter<DayOfWeek>
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.UpperCaseName)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek?>))]
 public partial class NullableUpperCaseEnumTests : RecordMarshalAsserter<DayOfWeek?>
 {
     public NullableUpperCaseEnumTests() : base(Enum.GetValues<DayOfWeek>().Cast<DayOfWeek?>().Append(null),
@@ -235,7 +235,7 @@ public partial class NullableUpperCaseEnumTests : RecordMarshalAsserter<DayOfWee
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.LowerCaseName)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek>))]
 public partial class LowerCaseEnumTests : RecordMarshalAsserter<DayOfWeek>
 {
     public LowerCaseEnumTests() : base(Enum.GetValues<DayOfWeek>(), x =>  new AttributeValue { S = x.ToString().ToLowerInvariant() })
@@ -255,7 +255,7 @@ public partial class LowerCaseEnumTests : RecordMarshalAsserter<DayOfWeek>
 }
 
 [DynamoDbMarshallerOptions(EnumConversion = EnumConversion.LowerCaseName)]
-[DynamoDBMarshaller(typeof(Container<DayOfWeek?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<DayOfWeek?>))]
 public partial class NullableLowerCaseEnumTests : RecordMarshalAsserter<DayOfWeek?>
 {
     public NullableLowerCaseEnumTests() : base(Enum.GetValues<DayOfWeek>().Cast<DayOfWeek?>().Append(null),

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/FloatTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/FloatTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<float>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<float>))]
 public partial class FloatTests : RecordMarshalAsserter<float>
 {
     public FloatTests() : base(new[] {3_000.5F}, x => new() {N = x.ToString(CultureInfo.InvariantCulture)})
@@ -21,7 +21,7 @@ public partial class FloatTests : RecordMarshalAsserter<float>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<float?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<float?>))]
 public partial class NullableFloatTests : RecordMarshalAsserter<float?>
 {
     public NullableFloatTests() : base(new float?[] {3_000.5F, null}, x => x is null ? null : new AttributeValue {N = x.Value.ToString(CultureInfo.InvariantCulture)})

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/GuidTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/GuidTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<Guid>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<Guid>))]
 public partial class GuidTests : RecordMarshalAsserter<Guid>
 {
     protected override Container<Guid> UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)
@@ -24,7 +24,7 @@ public partial class GuidTests : RecordMarshalAsserter<Guid>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<Guid?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<Guid?>))]
 public partial class NullableGuidTests : RecordMarshalAsserter<Guid?>
 {
     protected override Container<Guid?> UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/IntTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/IntTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<int>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<int>))]
 public partial class IntTests : RecordMarshalAsserter<int>
 {
 
@@ -20,7 +20,7 @@ public partial class IntTests : RecordMarshalAsserter<int>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<int?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<int?>))]
 public partial class NullableIntTests : RecordMarshalAsserter<int?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/LongTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/LongTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<long>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<long>))]
 public partial class LongTests : RecordMarshalAsserter<long>
 {
 
@@ -20,7 +20,7 @@ public partial class LongTests : RecordMarshalAsserter<long>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<long?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<long?>))]
 public partial class NullableLongTests : RecordMarshalAsserter<long?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/MemoryStreamTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/MemoryStreamTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<MemoryStream>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<MemoryStream>))]
 public partial class MemoryStreamTests : NotNullRecordElementMarshalAsserter<MemoryStream>
 {
 
@@ -22,7 +22,7 @@ public partial class MemoryStreamTests : NotNullRecordElementMarshalAsserter<Mem
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<MemoryStream?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<MemoryStream?>))]
 public partial class NullableMemoryStreamTests : RecordMarshalAsserter<MemoryStream?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/SByteTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/SByteTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<sbyte>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<sbyte>))]
 public partial class SByteTests : RecordMarshalAsserter<sbyte>
 {
     public SByteTests() : base(new sbyte[] {1, 3, 4, 5}, x => new AttributeValue {N = x.ToString()})
@@ -19,7 +19,7 @@ public partial class SByteTests : RecordMarshalAsserter<sbyte>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<sbyte?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<sbyte?>))]
 public partial class NullableSByteTests : RecordMarshalAsserter<sbyte?>
 {
     public NullableSByteTests() : base(new sbyte?[] {1, 3, 4, 5}.Append(null), x => x is null ? null : new AttributeValue {N = x.Value.ToString()})

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/ShortTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/ShortTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<short>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<short>))]
 public partial class ShortTests : RecordMarshalAsserter<short>
 {
 
@@ -20,7 +20,7 @@ public partial class ShortTests : RecordMarshalAsserter<short>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<short?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<short?>))]
 public partial class NullableShortTests : RecordMarshalAsserter<short?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/StringTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/StringTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<string>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<string>))]
 public partial class StringTests : NotNullRecordElementMarshalAsserter<string>
 {
     protected override Container<string> UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)
@@ -21,7 +21,7 @@ public partial class StringTests : NotNullRecordElementMarshalAsserter<string>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<string?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<string?>))]
 public partial class NullableStringTests : RecordMarshalAsserter<string?>
 {
     protected override Container<string?> UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/TimeOnlyTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/TimeOnlyTests.cs
@@ -4,7 +4,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<TimeOnly>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<TimeOnly>))]
 public partial class TimeOnlyTests : RecordMarshalAsserter<TimeOnly>
 {
     protected override Container<TimeOnly> UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)
@@ -21,7 +21,7 @@ public partial class TimeOnlyTests : RecordMarshalAsserter<TimeOnly>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<TimeOnly?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<TimeOnly?>))]
 public partial class NullableTimeOnlyTests : RecordMarshalAsserter<TimeOnly?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/TimeSpanTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/TimeSpanTests.cs
@@ -5,7 +5,7 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<TimeSpan>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<TimeSpan>))]
 public partial class TimeSpanTests : RecordMarshalAsserter<TimeSpan>
 {
     public TimeSpanTests() : base(new []{TimeSpan.FromDays(1)}, _ => new() {S = "P1D"})
@@ -23,7 +23,7 @@ public partial class TimeSpanTests : RecordMarshalAsserter<TimeSpan>
 
 }
 
-[DynamoDBMarshaller(typeof(Container<TimeSpan?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<TimeSpan?>))]
 public partial class NullableTimeSpanTests : RecordMarshalAsserter<TimeSpan?>
 {
     public NullableTimeSpanTests() : base(new TimeSpan?[]{TimeSpan.FromDays(1), null}, x => x is not null ? new() {S = "P1D"} : null)

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/UIntTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/UIntTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<uint>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<uint>))]
 public partial class UIntTests : RecordMarshalAsserter<uint>
 {
 
@@ -20,7 +20,7 @@ public partial class UIntTests : RecordMarshalAsserter<uint>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<uint?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<uint?>))]
 public partial class NullableUIntTests : RecordMarshalAsserter<uint?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/ULongTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/ULongTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<ulong>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ulong>))]
 public partial class ULongTests : RecordMarshalAsserter<ulong>
 {
 
@@ -20,7 +20,7 @@ public partial class ULongTests : RecordMarshalAsserter<ulong>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<ulong?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ulong?>))]
 public partial class NullableULongTests : RecordMarshalAsserter<ulong?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/UShortTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Types/UShortTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Types;
 
-[DynamoDBMarshaller(typeof(Container<ushort>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ushort>))]
 public partial class UShortTests : RecordMarshalAsserter<ushort>
 {
 
@@ -20,7 +20,7 @@ public partial class UShortTests : RecordMarshalAsserter<ushort>
     }
 }
 
-[DynamoDBMarshaller(typeof(Container<ushort?>))]
+[DynamoDBMarshaller(EntityType = typeof(Container<ushort?>))]
 public partial class NullableUShortTests : RecordMarshalAsserter<ushort?>
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/OptionalEntityTypeTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/OptionalEntityTypeTests.cs
@@ -1,0 +1,39 @@
+using Amazon.DynamoDBv2.Model;
+using DynamoDBGenerator.Attributes;
+using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
+namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
+
+public partial class OptionalEntityTypeTests : MarshalAsserter<OptionalEnitityTypeDTO>
+{
+    protected override IEnumerable<(OptionalEnitityTypeDTO element, Dictionary<string, AttributeValue> attributeValues)> Arguments()
+    {
+        var element1 = new OptionalEnitityTypeDTO { SampleField = "Hello" };
+        yield return (element1, ToDict(element1));
+        var element2 = new OptionalEnitityTypeDTO { SampleField = "Wolrd" };
+        yield return (element2, ToDict(element2));
+
+        static Dictionary<string, AttributeValue> ToDict(OptionalEnitityTypeDTO element)
+        {
+            return new Dictionary<string, AttributeValue> {
+              {nameof(element.SampleField), new AttributeValue{S = element.SampleField}}
+            };
+        }
+    }
+
+    protected override Dictionary<string, AttributeValue> MarshallImplementation(OptionalEnitityTypeDTO element)
+    {
+        return OptionalEnitityTypeDTO.OptionalEnitityTypeDTOMarshaller.Marshall(element);
+    }
+
+    protected override OptionalEnitityTypeDTO UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)
+    {
+        return OptionalEnitityTypeDTO.OptionalEnitityTypeDTOMarshaller.Unmarshall(attributeValues);
+    }
+}
+
+[DynamoDBMarshaller]
+public partial record OptionalEnitityTypeDTO
+{
+
+    public string? SampleField { get; set; }
+}

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/PrimitiveArgumentTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/PrimitiveArgumentTests.cs
@@ -4,9 +4,9 @@ using DynamoDBGenerator.Extensions;
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(typeof((Guid, Guid)), PropertyName = "STRING", ArgumentType = typeof(string))]
-[DynamoDBMarshaller(typeof((Guid, Guid)), PropertyName = "GUID", ArgumentType = typeof(Guid))]
-[DynamoDBMarshaller(typeof((Guid, Guid)), PropertyName = "INT", ArgumentType = typeof(int))]
+[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), PropertyName = "STRING", ArgumentType = typeof(string))]
+[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), PropertyName = "GUID", ArgumentType = typeof(Guid))]
+[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), PropertyName = "INT", ArgumentType = typeof(int))]
 public partial class PrimitiveArgumentTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/RenameSourceGeneratedPropertyTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/RenameSourceGeneratedPropertyTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(typeof(WillHaveChangedPropertyName), PropertyName = "SomethingElse")]
+[DynamoDBMarshaller(EntityType = typeof(WillHaveChangedPropertyName), PropertyName = "SomethingElse")]
 public partial class RenameSourceGeneratedPropertyTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/CustomObjects/ChildClassTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/CustomObjects/ChildClassTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.CustomObjects;
 
-[DynamoDBMarshaller(typeof(ParentClass))]
+[DynamoDBMarshaller(EntityType = typeof(ParentClass))]
 public partial class ChildClassTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/CustomObjects/SiblingClassTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/CustomObjects/SiblingClassTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.CustomObjects;
 
-[DynamoDBMarshaller(typeof(SiblingClassOne))]
+[DynamoDBMarshaller(EntityType = typeof(SiblingClassOne))]
 public partial class SiblingClassTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/FieldInclusionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/FieldInclusionTests.cs
@@ -1,10 +1,10 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize;
 
-[DynamoDBMarshaller(typeof(EmptyClass))]
-[DynamoDBMarshaller(typeof(ClassWithIgnoredField))]
-[DynamoDBMarshaller(typeof(ClassWithOneField))]
-[DynamoDBMarshaller(typeof(ClassWithOneDDBField))]
+[DynamoDBMarshaller(EntityType = typeof(EmptyClass))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithIgnoredField))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithOneField))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithOneDDBField))]
 public partial class FieldInclusionTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/CollectionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/CollectionTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.Generics;
 
-[DynamoDBMarshaller(typeof(CollectionClass))]
+[DynamoDBMarshaller(EntityType = typeof(CollectionClass))]
 public partial class CollectionTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/DictionaryTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/DictionaryTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.Generics;
 
-[DynamoDBMarshaller(typeof(DictionaryClass))]
+[DynamoDBMarshaller(EntityType = typeof(DictionaryClass))]
 public partial class DictionaryTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/KeyValuePairTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/KeyValuePairTests.cs
@@ -4,7 +4,7 @@ namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serializ
 // TODO these tests are giving warnings due to the return type of Unmarshall does not take nullability into account.
 // This could maybe be solved by digging down into generic the types in order to determine whether they should be nullable and then build the return type based on that information.
 // This behaviour is already solved for methods that should follow the nullability of data members.
-[DynamoDBMarshaller(typeof(KeyValuePairClass))]
+[DynamoDBMarshaller(EntityType = typeof(KeyValuePairClass))]
 public partial class KeyValuePairTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/LookUpTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/LookUpTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.Generics;
 
-[DynamoDBMarshaller(typeof(LookUpClass))]
+[DynamoDBMarshaller(EntityType = typeof(LookUpClass))]
 public partial class LookUpTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/NullableTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/NullableTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.Generics;
 
-[DynamoDBMarshaller(typeof(NullableValueTypeClass))]
+[DynamoDBMarshaller(EntityType = typeof(NullableValueTypeClass))]
 public partial class NullableTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/TupleTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/TupleTests.cs
@@ -1,10 +1,10 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.Generics;
 
-[DynamoDBMarshaller(typeof(TupleClass))]
-[DynamoDBMarshaller(typeof((int X, int Y)), PropertyName = "XAndYTuple")]
-[DynamoDBMarshaller(typeof((int, int )), PropertyName = "UnnamedTuple")]
-[DynamoDBMarshaller(typeof((string Id, (int X, int Y) Coordinates)), PropertyName = "NestedXAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof(TupleClass))]
+[DynamoDBMarshaller(EntityType = typeof((int X, int Y)), PropertyName = "XAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof((int, int )), PropertyName = "UnnamedTuple")]
+[DynamoDBMarshaller(EntityType = typeof((string Id, (int X, int Y) Coordinates)), PropertyName = "NestedXAndYTuple")]
 public partial class TupleTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/InheritanceTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/InheritanceTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize;
 
-[DynamoDBMarshaller(typeof(Cat))]
+[DynamoDBMarshaller(EntityType = typeof(Cat))]
 public partial class InheritanceTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/NullableAnnotationTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/NullableAnnotationTests.cs
@@ -3,8 +3,8 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Exceptions;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize;
 
-[DynamoDBMarshaller(typeof(NestedNullableAnnotationTestClass))]
-[DynamoDBMarshaller(typeof(NullableAnnotationTestClass))]
+[DynamoDBMarshaller(EntityType = typeof(NestedNullableAnnotationTestClass))]
+[DynamoDBMarshaller(EntityType = typeof(NullableAnnotationTestClass))]
 public partial class NullableAnnotationTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/PropertyInclusionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/PropertyInclusionTests.cs
@@ -1,10 +1,10 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize;
 
-[DynamoDBMarshaller(typeof(EmptyClass))]
-[DynamoDBMarshaller(typeof(ClassWithIgnoredProperty))]
-[DynamoDBMarshaller(typeof(ClassWithOneProperty))]
-[DynamoDBMarshaller(typeof(ClassWithOneDDBProperty))]
+[DynamoDBMarshaller(EntityType = typeof(EmptyClass))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithIgnoredProperty))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithOneProperty))]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithOneDDBProperty))]
 public partial class PropertyInclusionTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/PropertyRenamingTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/PropertyRenamingTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize;
 
-[DynamoDBMarshaller(typeof(PropertyWithMixedNames))]
+[DynamoDBMarshaller(EntityType = typeof(PropertyWithMixedNames))]
 public partial class PropertyRenamingTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/ReferenceTypeTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/ReferenceTypeTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize;
 
-[DynamoDBMarshaller(typeof(ReferenceTypeClass))]
+[DynamoDBMarshaller(EntityType = typeof(ReferenceTypeClass))]
 public partial class ReferenceTypeTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/ValueTypeTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/ValueTypeTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize;
 
-[DynamoDBMarshaller(typeof(ValueTypeClass))]
+[DynamoDBMarshaller(EntityType = typeof(ValueTypeClass))]
 public partial class ValueTypeTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBPrimaryKeyMarshallerTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBPrimaryKeyMarshallerTests.cs
@@ -6,10 +6,10 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Exceptions;
 namespace DynamoDBGenerator.SourceGenerator.Tests;
 
-[DynamoDBMarshaller(typeof(TypeWithPartitionKeyOnly), PropertyName = "PartitionKeyOnly")]
-[DynamoDBMarshaller(typeof(TypeWithRangeKeyOnly), PropertyName = "TypeWithRangeOnly")]
-[DynamoDBMarshaller(typeof(TypeWithKeys), PropertyName = "TypeWithKeys")]
-[DynamoDBMarshaller(typeof(TypeWithoutKeys), PropertyName = "TypeWithoutKeys")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithPartitionKeyOnly), PropertyName = "PartitionKeyOnly")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithRangeKeyOnly), PropertyName = "TypeWithRangeOnly")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithKeys), PropertyName = "TypeWithKeys")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithoutKeys), PropertyName = "TypeWithoutKeys")]
 public partial class DynamoDBPrimaryKeyMarshallerTests
 {
     private readonly Fixture _fixture = new();

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/Extensions/ToAttributeExpressionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/Extensions/ToAttributeExpressionTests.cs
@@ -3,7 +3,7 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Extensions;
 namespace DynamoDBGenerator.SourceGenerator.Tests.Extensions;
 
-[DynamoDBMarshaller(typeof(OrderAttributeExpressionTests))]
+[DynamoDBMarshaller(EntityType = typeof(OrderAttributeExpressionTests))]
 public partial class ToAttributeExpressionTests
 {
     private readonly Fixture _fixture = new();


### PR DESCRIPTION
The type where `DynamoDBMarshallerAttribute` is applied will be assumed to be `EntityType` unless `EntityType` is explicitily set to a different type.

This allows for marshallers to be applied directly to DTO's or into a repository pattern when you explicitly set `EntityType`.