### PR TITLE
Rename PropertyName -> AccessName

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ public class Person
 #### UpdateRequest without providing the DTO
 
 ```csharp
-// A typical scenario would be that you would use multuple DynamoDBMarshaller and describe your operaitons via PropertyName.
+// A typical scenario would be that you would use multuple DynamoDBMarshaller and describe your operaitons via AccessName.
 // If you do not specify an ArgumentType it will use your main entity Type instead which is typically useful for PUT operations.
-[DynamoDBMarshaller(EntityType = typeof(Person), ArgumentType = typeof((string PersonId, string Firstname)), PropertyName = "UpdateFirstName")]
+[DynamoDBMarshaller(EntityType = typeof(Person), ArgumentType = typeof((string PersonId, string Firstname)), AccessName = "UpdateFirstName")]
 public partial class Repository { }
 
 internal static class Program
@@ -218,7 +218,7 @@ The source generator will internally validate your object arguments. So if you p
 
 ```csharp
 
-[DynamoDBMarshaller(PropertyName = 'KeyMarshallerSample')]
+[DynamoDBMarshaller(AccessName = 'KeyMarshallerSample')]
 public class EntityDTO
 {
     [DynamoDBHashKey("PK")]
@@ -287,7 +287,7 @@ public class MyCustomConverters : AttributeValueConverters
 }
 
 [DynamoDBMarshallerOptions(Converter = typeof(MyCustomConverters))]
-[DynamoDBMarshaller(EntityType = typeof(Person), PropertyName = "PersonMarshaller")]
+[DynamoDBMarshaller(EntityType = typeof(Person), AccessName = "PersonMarshaller")]
 public partial Repository 
 {
 
@@ -298,7 +298,7 @@ public partial Repository
 
 ```csharp
 [DynamoDBMarshallerOptions(EnumConversion = EnumConversion.Name)]
-[DynamoDBMarshaller(EntityType = typeof(Person), PropertyName = "PersonMarshaller")]
+[DynamoDBMarshaller(EntityType = typeof(Person), AccessName = "PersonMarshaller")]
 public partial class Repository { }
 ```
 

--- a/src/DynamoDBGenerator.SourceGenerator/Constants.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Constants.cs
@@ -13,7 +13,7 @@ public static class Constants
             public static class DynamoDBMarshallerArgument
             {
                 public const string EntityType = "EntityType";
-                public const string PropertyName = "PropertyName";
+                public const string AccessName = "AccessName";
                 public const string ArgumentType = "ArgumentType";
             }
             public static class DynamoDbMarshallerOptionsArgument

--- a/src/DynamoDBGenerator.SourceGenerator/DynamoDBDMarshallerEntry.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/DynamoDBDMarshallerEntry.cs
@@ -150,7 +150,7 @@ using {Constants.DynamoDBGenerator.Namespace.InternalFullName};";
                     throw new ArgumentException("Could not determine type conversion from attribute constructor.");
 
                 var propertyName = attributeData.NamedArguments.FirstOrDefault(x =>
-                    x.Key is Constants.DynamoDBGenerator.Attribute.DynamoDBMarshallerArgument.PropertyName).Value;
+                    x.Key is Constants.DynamoDBGenerator.Attribute.DynamoDBMarshallerArgument.AccessName).Value;
                 yield return new DynamoDBMarshallerArguments(
                     entityTypeSymbol,
                     attributeData.NamedArguments

--- a/src/DynamoDBGenerator.SourceGenerator/DynamoDbMarshaller.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/DynamoDbMarshaller.cs
@@ -38,8 +38,8 @@ public static class DynamoDbMarshaller
             yield return options.TryInstantiate() switch
             {
                 {} arg =>
-                    $"public static {Interface}<{entityTypeName}, {argumentTypeName}, {nameTrackerTypeName}, {valueTrackerTypeName}> {argument.PropertyName} {{ get; }} = new {argument.ImplementationName}({arg});",
-                null => $"public static {Interface}<{entityTypeName}, {argumentTypeName}, {nameTrackerTypeName}, {valueTrackerTypeName}> {argument.PropertyName}({MarshallerOptions.Name} options) => new {argument.ImplementationName}(options);"
+                    $"public static {Interface}<{entityTypeName}, {argumentTypeName}, {nameTrackerTypeName}, {valueTrackerTypeName}> {argument.Accessname} {{ get; }} = new {argument.ImplementationName}({arg});",
+                null => $"public static {Interface}<{entityTypeName}, {argumentTypeName}, {nameTrackerTypeName}, {valueTrackerTypeName}> {argument.Accessname}({MarshallerOptions.Name} options) => new {argument.ImplementationName}(options);"
             };
 
             foreach (var s in classImplementation)

--- a/src/DynamoDBGenerator.SourceGenerator/Types/DynamoDBMarshallerArguments.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Types/DynamoDBMarshallerArguments.cs
@@ -10,8 +10,8 @@ public readonly record struct DynamoDBMarshallerArguments
         ArgumentType = argumentType is null
             ? EntityTypeSymbol
             : (INamedTypeSymbol)argumentType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
-        PropertyName = propertyName ?? $"{EntityTypeSymbol.Name}Marshaller";
-        ImplementationName = $"{PropertyName}Implementation";
+        Accessname = propertyName ?? $"{EntityTypeSymbol.Name}Marshaller";
+        ImplementationName = $"{Accessname}Implementation";
 
         AnnotatedEntityType = EntityTypeSymbol.Representation().annotated;
         AnnotatedArgumentType = argumentType is null ? AnnotatedEntityType : ArgumentType.Representation().annotated;
@@ -20,7 +20,7 @@ public readonly record struct DynamoDBMarshallerArguments
     public string ImplementationName { get; }
     public INamedTypeSymbol EntityTypeSymbol { get; }
     public INamedTypeSymbol ArgumentType { get; }
-    public string PropertyName { get; }
+    public string Accessname { get; }
 
     public string AnnotatedEntityType { get; }
     public string AnnotatedArgumentType { get; }

--- a/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
+++ b/src/DynamoDBGenerator/Attributes/DynamoDBMarshallerAttribute.cs
@@ -23,7 +23,7 @@ namespace DynamoDBGenerator.Attributes;
 ///                 }
 ///             }
 ///         }
-///         [DynamoDBMarshaller(EntityType = typeof(OrderEntity), PropertyName = "MyCustomPropertyName"))]
+///         [DynamoDBMarshaller(EntityType = typeof(OrderEntity), AccessName = "MyCustomPropertyName"))]
 ///         public class OrderEntity
 ///         {
 ///             [DynamoDBHashKey]
@@ -44,12 +44,17 @@ public class DynamoDBMarshallerAttribute : Attribute
     public Type? EntityType { get; set; }
 
     /// <summary>
-    /// Gets or sets the name of the property to use when accessing the marshaller.
+    /// Gets or sets the name for how the marshaller is accessed.
     /// </summary>
     /// <remarks>
-    /// The default value will be dependant on the <see cref="EntityType"/> by having the naming format of `{Type.Name}Marshaller` but without the reflection.
+    /// <para> 
+    ///   The default value will be dependant on the <see cref="EntityType"/> by having the naming format of `{Type.Name}Marshaller` but without the reflection.
+    /// </para>
+    /// <para>
+    ///   By default it the marshaller can be accessed as a property, but can be transformed into a method if you add constructor dependencies to <see cref="DynamoDbMarshallerOptionsAttribute.Converters" />
+    /// </para>
     /// </remarks>
-    public string? PropertyName { get; set; }
+    public string? AccessName { get; set; }
 
     /// <summary>
     /// Gets or sets the type that <see cref="IDynamoDBMarshaller{TEntity,TArg,TEntityAttributeNameTracker,TArgumentAttributeValueTracker}"/>

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/TupleTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/Generics/TupleTests.cs
@@ -3,9 +3,9 @@ using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserialize.Generics;
 
 [DynamoDBMarshaller(EntityType = typeof(TupleClass))]
-[DynamoDBMarshaller(EntityType = typeof((int X, int Y)), PropertyName = "XAndYTuple")]
-[DynamoDBMarshaller(EntityType = typeof((int, int )), PropertyName = "UnnamedTuple")]
-[DynamoDBMarshaller(EntityType = typeof((string Id, (int X, int Y) Coordinates)), PropertyName = "NestedXAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof((int X, int Y)), AccessName = "XAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof((int, int )), AccessName = "UnnamedTuple")]
+[DynamoDBMarshaller(EntityType = typeof((string Id, (int X, int Y) Coordinates)), AccessName = "NestedXAndYTuple")]
 public partial class TupleTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/InitializationTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Deserialize/InitializationTests.cs
@@ -9,8 +9,8 @@ namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Deserial
 [DynamoDBMarshaller(EntityType = typeof(InlinedRecord))]
 [DynamoDBMarshaller(EntityType = typeof(ExplicitConstructorRecord))]
 [DynamoDBMarshaller(EntityType = typeof(InlineRecordWithNestedRecord))]
-[DynamoDBMarshaller(EntityType = typeof(ClassWithConstructorThatObjectInitializerShouldOnlyBeUsed), PropertyName = "InitializerOnly")]
-[DynamoDBMarshaller(EntityType = typeof(ClassWithConstructorThatShouldOnlyBeUsed), PropertyName = "ConstructorOnly")]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithConstructorThatObjectInitializerShouldOnlyBeUsed), AccessName = "InitializerOnly")]
+[DynamoDBMarshaller(EntityType = typeof(ClassWithConstructorThatShouldOnlyBeUsed), AccessName = "ConstructorOnly")]
 public partial class InitializationTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/ExpressionAttributeTrackerTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/ExpressionAttributeTrackerTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(EntityType = typeof(Person), ArgumentType = typeof((string firstName, DateTime timeStamp)), PropertyName = "PersonWithTupleArgument")]
+[DynamoDBMarshaller(EntityType = typeof(Person), ArgumentType = typeof((string firstName, DateTime timeStamp)), AccessName = "PersonWithTupleArgument")]
 [DynamoDBMarshaller(EntityType = typeof(Person))]
 [DynamoDBMarshaller(EntityType = typeof(SelfReferencingClass))]
 [DynamoDBMarshaller(EntityType = typeof(ClassWithOverriddenAttributeName))]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/TupleArgumentTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Tuples/TupleArgumentTests.cs
@@ -4,8 +4,8 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Extensions;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Tuples;
 
-[DynamoDBMarshaller(EntityType = typeof(Animal), ArgumentType = typeof((string Id, Animal.Status Status, DateTime TimeStamp)), PropertyName = "SetStatus")]
-[DynamoDBMarshaller(EntityType = typeof(Animal), PropertyName = "SaveAnimal", ArgumentType = typeof((Animal animal, Animal.Status adopted, Animal.Status pending)))]
+[DynamoDBMarshaller(EntityType = typeof(Animal), ArgumentType = typeof((string Id, Animal.Status Status, DateTime TimeStamp)), AccessName = "SetStatus")]
+[DynamoDBMarshaller(EntityType = typeof(Animal), AccessName = "SaveAnimal", ArgumentType = typeof((Animal animal, Animal.Status adopted, Animal.Status pending)))]
 public partial class TupleArgumentTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/PrimitiveArgumentTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/PrimitiveArgumentTests.cs
@@ -4,9 +4,9 @@ using DynamoDBGenerator.Extensions;
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), PropertyName = "STRING", ArgumentType = typeof(string))]
-[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), PropertyName = "GUID", ArgumentType = typeof(Guid))]
-[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), PropertyName = "INT", ArgumentType = typeof(int))]
+[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), AccessName = "STRING", ArgumentType = typeof(string))]
+[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), AccessName = "GUID", ArgumentType = typeof(Guid))]
+[DynamoDBMarshaller(EntityType = typeof((Guid, Guid)), AccessName = "INT", ArgumentType = typeof(int))]
 public partial class PrimitiveArgumentTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/RenameSourceGeneratedPropertyTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/RenameSourceGeneratedPropertyTests.cs
@@ -1,7 +1,7 @@
 using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests;
 
-[DynamoDBMarshaller(EntityType = typeof(WillHaveChangedPropertyName), PropertyName = "SomethingElse")]
+[DynamoDBMarshaller(EntityType = typeof(WillHaveChangedPropertyName), AccessName = "SomethingElse")]
 public partial class RenameSourceGeneratedPropertyTests
 {
 

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/TupleTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Serialize/Generics/TupleTests.cs
@@ -2,9 +2,9 @@ using DynamoDBGenerator.Attributes;
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Serialize.Generics;
 
 [DynamoDBMarshaller(EntityType = typeof(TupleClass))]
-[DynamoDBMarshaller(EntityType = typeof((int X, int Y)), PropertyName = "XAndYTuple")]
-[DynamoDBMarshaller(EntityType = typeof((int, int )), PropertyName = "UnnamedTuple")]
-[DynamoDBMarshaller(EntityType = typeof((string Id, (int X, int Y) Coordinates)), PropertyName = "NestedXAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof((int X, int Y)), AccessName = "XAndYTuple")]
+[DynamoDBMarshaller(EntityType = typeof((int, int )), AccessName = "UnnamedTuple")]
+[DynamoDBMarshaller(EntityType = typeof((string Id, (int X, int Y) Coordinates)), AccessName = "NestedXAndYTuple")]
 public partial class TupleTests
 {
     [Fact]

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBPrimaryKeyMarshallerTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBPrimaryKeyMarshallerTests.cs
@@ -6,10 +6,10 @@ using DynamoDBGenerator.Attributes;
 using DynamoDBGenerator.Exceptions;
 namespace DynamoDBGenerator.SourceGenerator.Tests;
 
-[DynamoDBMarshaller(EntityType = typeof(TypeWithPartitionKeyOnly), PropertyName = "PartitionKeyOnly")]
-[DynamoDBMarshaller(EntityType = typeof(TypeWithRangeKeyOnly), PropertyName = "TypeWithRangeOnly")]
-[DynamoDBMarshaller(EntityType = typeof(TypeWithKeys), PropertyName = "TypeWithKeys")]
-[DynamoDBMarshaller(EntityType = typeof(TypeWithoutKeys), PropertyName = "TypeWithoutKeys")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithPartitionKeyOnly), AccessName = "PartitionKeyOnly")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithRangeKeyOnly), AccessName = "TypeWithRangeOnly")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithKeys), AccessName = "TypeWithKeys")]
+[DynamoDBMarshaller(EntityType = typeof(TypeWithoutKeys), AccessName = "TypeWithoutKeys")]
 public partial class DynamoDBPrimaryKeyMarshallerTests
 {
     private readonly Fixture _fixture = new();


### PR DESCRIPTION
Since the way you access a marshaller can change to a method if you introduce constructor dependencies through the `Converters` `type` on the `DynamoDBMarshallerOptionsAttribute`. It's better to call it AccessName in order to give be more accurare on what the property represents.