### PR TITLE
Fix typo in TimeSpan converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you do not override the conversion behaviour the following rules will be appl
 | `IDictonary<string, TValue>`         | `M`   | Will treat the `Dictionary` as a **Key-Value** store. |
 | `IEnumerable<T>`                     | `L`   |                                                       |
 | `IReadOnlyList<T>`                   | `L`   |                                                       |
-| `IRedonlyDictionary<string, TValue>` | `M`   | Will treat the `Dictionary` as a **Key-Value** store. |
+| `IReadonlyDictionary<string, TValue>` | `M`   | Will treat the `Dictionary` as a **Key-Value** store. |
 | `ILookup<string, TValue>`            | `M`   | Will treat the `ILookup` as a **Key-Values** store.   |
 | `ISet<int>`                          | `NS`  |                                                       |
 | `ISet<long>`                         | `NS`  |                                                       |

--- a/src/DynamoDBGenerator/Converters/Internal/ISO8601TimeSpanConverter.cs
+++ b/src/DynamoDBGenerator/Converters/Internal/ISO8601TimeSpanConverter.cs
@@ -4,7 +4,7 @@ using Amazon.DynamoDBv2.Model;
 
 namespace DynamoDBGenerator.Converters.Internal;
 
-internal sealed class ISO8601TimeSpanConveter : IValueTypeConverter<TimeSpan>
+internal sealed class ISO8601TimeSpanConverter : IValueTypeConverter<TimeSpan>
 {
     public TimeSpan? Read(AttributeValue attributeValue)
     {

--- a/src/DynamoDBGenerator/Options/AttributeValueConverters.cs
+++ b/src/DynamoDBGenerator/Options/AttributeValueConverters.cs
@@ -109,7 +109,7 @@ public class AttributeValueConverters
     /// <summary>
     /// The <see cref="TimeSpan"/> converter.
     /// </summary>
-    public IValueTypeConverter<TimeSpan> TimeSpanConverter { get; protected init;} = new ISO8601TimeSpanConveter();
+    public IValueTypeConverter<TimeSpan> TimeSpanConverter { get; protected init;} = new ISO8601TimeSpanConverter();
     
     /// <summary>
     /// The <see cref="Guid"/> converter.


### PR DESCRIPTION
## Summary
- fix typo `ISO8601TimeSpanConveter` -> `ISO8601TimeSpanConverter`
- update usage in default converters
- fix small typo in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846e0639fac832e961f73a013351025