### PR TITLE
fix: correct nullability spelling in exception

### DIFF
--- a/src/DynamoDBGenerator.SourceGenerator/Types/TypeIdentifier.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Types/TypeIdentifier.cs
@@ -24,7 +24,7 @@ public abstract record TypeIdentifier
             { IsValueType: true, OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } => true,
             { IsValueType: true } => false,
             _ => throw new ArgumentOutOfRangeException(
-                $"Could not determine nullablity of type '{typeSymbol.ToDisplayString()}'.")
+                $"Could not determine nullability of type '{typeSymbol.ToDisplayString()}'.")
         };
 
         TypeSymbol = typeSymbol;


### PR DESCRIPTION
## Summary
- fix a typo in `TypeIdentifier` exception message

## Testing
- `dotnet build DynamoDBGenerator.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846e20f34f0832eb1d658ccaf437661