### PR TITLE
chore: fix comment wording

### DIFF
--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/Extensions/ToAttributeExpressionTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/Extensions/ToAttributeExpressionTests.cs
@@ -50,7 +50,7 @@ public partial class ToAttributeExpressionTests
                 (x, y) => $"{x.Id} = {y.Id}");
 
         // Order of Values and Names do not match the access pattern in the expression.
-        // Their order is based on the the order of the yield returns of AccessedValues and AccessedNames.
+        // Their order is based on the order of the yield returns of AccessedValues and AccessedNames.
         result.Values
             .Should()
             .SatisfyRespectively(


### PR DESCRIPTION
## Summary
- fix comment in `ToAttributeExpressionTests` to remove repeated word

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846e210455c832e95fb4c34805bb409