### PR TITLE
Fix syntax error with code generation for sets

### DIFF
--- a/src/DynamoDBGenerator.SourceGenerator/Generations/UnMarshaller.cs
+++ b/src/DynamoDBGenerator.SourceGenerator/Generations/UnMarshaller.cs
@@ -132,7 +132,7 @@ public static class UnMarshaller
                     .CreateScope(
                         $"if ({Value} is null || {Value}.SS is null)"
                             .CreateScope(singleGeneric.ReturnNullOrThrow(DataMember))
-                            .Append($"return new {(singleGeneric.TypeSymbol.TypeKind is TypeKind.Interface ? $"HashSet<{(singleGeneric.T.IsSupposedToBeNull ? "string?" : "string")}>" : null)}({(singleGeneric.T.IsSupposedToBeNull ? $"{Value}.SS" : $"{Value}.SS.Select((y,i) => y ?? throw {ExceptionHelper.NullExceptionMethod}($\"{{{DataMember}}}[UNKNOWN]\")")}));")
+                            .Append($"return new {(singleGeneric.TypeSymbol.TypeKind is TypeKind.Interface ? $"HashSet<{(singleGeneric.T.IsSupposedToBeNull ? "string?" : "string")}>" : null)}({(singleGeneric.T.IsSupposedToBeNull ? $"{Value}.SS" : $"{Value}.SS.Select((y,i) => y ?? throw {ExceptionHelper.NullExceptionMethod}($\"{{{DataMember}}}[UNKNOWN]\"))")});")
                         )
                     .ToConversion(),
                 SingleGeneric.SupportedType.Set when singleGeneric.T.IsNumeric => signature

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/Asserters/NoneNullableElementAsserter.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/Asserters/NoneNullableElementAsserter.cs
@@ -3,21 +3,19 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
 
-public abstract class NoneNullableElementAsserter<TSet, TElement> : SetAsserter<TSet, TElement>
-    where TSet : IEnumerable<TElement> where TElement : class
+public abstract class NoneNullableElementAsserter<TSet, TElement>(
+    IEnumerable<TElement> seed,
+    Func<IEnumerable<TElement>, TSet> fn
+) : SetAsserter<TSet, TElement>(seed, fn)
+    where TSet : IEnumerable<TElement>
+    where TElement : class
 {
-    protected NoneNullableElementAsserter(IEnumerable<TElement> seed, Func<IEnumerable<TElement>, TSet> fn) : base(seed,
-        fn)
-    {
-    }
-
     protected static IEnumerable<string> Strings()
     {
         yield return "John";
         yield return "Tom";
         yield return "Michael";
     }
-
 
     [Fact]
     public void Marshall_NullElement_ShouldThrow()

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/Asserters/NullableElementAsserter.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/Asserters/NullableElementAsserter.cs
@@ -1,0 +1,29 @@
+namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
+
+public abstract class NullableElementAsserter<TSet, TElement> : SetAsserter<TSet, TElement?>
+    where TSet : IEnumerable<TElement?> where TElement : class
+{
+    protected NullableElementAsserter(IEnumerable<TElement?> seed, Func<IEnumerable<TElement?>, TSet> fn) : base(seed,
+        fn)
+    {
+    }
+
+    protected static IEnumerable<string> Strings()
+    {
+        yield return "John";
+        yield return "Tom";
+        yield return "Michael";
+    }
+
+    [Fact]
+    public void Marshall_NullElement_ShouldNotThrow()
+    {
+        Arguments().Should().AllSatisfy(x =>
+        {
+            var items = x.element.Element.Append(null).ToList();
+            var args = CreateArguments(items);
+            var act = () => MarshallImplementation(args.element);
+            act.Should().NotThrow();
+        });
+    }
+}

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/Asserters/SetAsserter.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/Asserters/SetAsserter.cs
@@ -4,29 +4,25 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.A
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
 
-public abstract class SetAsserter<TSet, TElement> : MarshalAsserter<Container<TSet>> where TSet : IEnumerable<TElement>
+public abstract class SetAsserter<TSet, TElement>(
+    IEnumerable<TElement> seed,
+    Func<IEnumerable<TElement>, TSet> fn
+) : MarshalAsserter<Container<TSet>>
+    where TSet : IEnumerable<TElement>
 {
     private static readonly bool IsStringSet = typeof(TElement) == typeof(string);
-    private readonly Func<IEnumerable<TElement>, TSet> _fn;
-    private readonly IEnumerable<TElement> _seed;
-
-    protected SetAsserter(IEnumerable<TElement> seed, Func<IEnumerable<TElement>, TSet> fn)
-    {
-        _seed = seed;
-        _fn = fn;
-    }
 
 
     protected override IEnumerable<(Container<TSet> element, Dictionary<string, AttributeValue> attributeValues)>
         Arguments()
     {
-        yield return CreateArguments(_seed);
+        yield return CreateArguments(seed);
     }
 
     protected (Container<TSet> element, Dictionary<string, AttributeValue> attributeValues) CreateArguments(
         IEnumerable<TElement> arg)
     {
-        var res = _fn(arg);
+        var res = fn(arg);
         if (res is not IReadOnlySet<TElement> or not ISet<TElement>)
             throw new InvalidOperationException(
                 $"The type '{nameof(TSet)}' must either one of  'ISet<{nameof(TElement)}>, 'IReadonlySet<{nameof(TElement)}>'.");

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/HashSetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/HashSetTests.cs
@@ -6,12 +6,9 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.G
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
 [DynamoDBMarshaller(EntityType = typeof(Container<HashSet<string>>))]
-public partial class HashSetTests : NoneNullableElementAsserter<HashSet<string>, string>
+public partial class HashSetTests()
+    : NoneNullableElementAsserter<HashSet<string>, string>(Strings(), x => new HashSet<string>(x))
 {
-    public HashSetTests() : base(Strings(), x => new HashSet<string>(x))
-    {
-    }
-
     protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<HashSet<string>> element)
     {
         return ContainerMarshaller.Marshall(element);

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IReadOnlySetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IReadOnlySetTests.cs
@@ -6,12 +6,9 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.G
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
 [DynamoDBMarshaller(EntityType = typeof(Container<IReadOnlySet<string>>))]
-public partial class IReadOnlySetTests : NoneNullableElementAsserter<IReadOnlySet<string>, string>
+public partial class IReadOnlySetTests()
+    : NoneNullableElementAsserter<IReadOnlySet<string>, string>(Strings(), x => new SortedSet<string>(x))
 {
-    public IReadOnlySetTests() : base(Strings(), x => new SortedSet<string>(x))
-    {
-    }
-
     protected override Dictionary<string, AttributeValue> MarshallImplementation(
         Container<IReadOnlySet<string>> element)
     {

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/ISetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/ISetTests.cs
@@ -6,12 +6,8 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.G
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
 [DynamoDBMarshaller(EntityType = typeof(Container<ISet<string>>))]
-public partial class ISetTests : NoneNullableElementAsserter<ISet<string>, string>
+public partial class ISetTests() : NoneNullableElementAsserter<ISet<string>, string>(Strings(), x => new HashSet<string>(x))
 {
-    public ISetTests() : base(Strings(), x => new HashSet<string>(x))
-    {
-    }
-
     protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<ISet<string>> element)
     {
         return ContainerMarshaller.Marshall(element);

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IntHashSetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/IntHashSetTests.cs
@@ -6,12 +6,8 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.G
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
 [DynamoDBMarshaller(EntityType = typeof(Container<HashSet<int>>))]
-public partial class IntHashSetTests : SetAsserter<HashSet<int>, int>
+public partial class IntHashSetTests() : SetAsserter<HashSet<int>, int>([2, 3, 4, 5], x => new HashSet<int>(x))
 {
-    public IntHashSetTests() : base(new[] { 2, 3, 4, 5 }, x => new HashSet<int>(x))
-    {
-    }
-
     protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<HashSet<int>> element)
     {
         return ContainerMarshaller.Marshall(element);
@@ -23,6 +19,22 @@ public partial class IntHashSetTests : SetAsserter<HashSet<int>, int>
         return ContainerMarshaller.Unmarshall(attributeValues);
     }
 }
+
+// TODO Support
+//[DynamoDBMarshaller(EntityType = typeof(Container<HashSet<int?>>))]
+//public partial class NUllableIntHashSetTests() : SetAsserter<HashSet<int?>, int?>([2, 3, 4, 5], x => new HashSet<int?>(x))
+//{
+//    protected override Container<HashSet<int?>> UnmarshallImplementation(
+//        Dictionary<string, AttributeValue> attributeValues)
+//    {
+//        return ContainerMarshaller.Unmarshall(attributeValues);
+//    }
+//
+//    protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<HashSet<int?>> element)
+//    {
+//        return ContainerMarshaller.Marshall(element);
+//    }
+//}
 
 [DynamoDBMarshaller(EntityType = typeof(Container<HashSet<decimal>>))]
 public partial class DecimalHashSetTests : SetAsserter<HashSet<decimal>, decimal>

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableHashSetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableHashSetTests.cs
@@ -1,0 +1,20 @@
+using Amazon.DynamoDBv2.Model;
+using DynamoDBGenerator.Attributes;
+using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
+using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
+
+namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
+
+[DynamoDBMarshaller(EntityType = typeof(Container<HashSet<string?>>))]
+public partial class NullableHashSetTests() : NullableElementAsserter<HashSet<string?>, string>(Strings(), x => new HashSet<string?>(x))
+{
+    protected override Container<HashSet<string?>> UnmarshallImplementation(Dictionary<string, AttributeValue> attributeValues)
+    {
+        return ContainerMarshaller.Unmarshall(attributeValues);
+    }
+
+    protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<HashSet<string?>> element)
+    {
+        return ContainerMarshaller.Marshall(element);
+    }
+}

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableIReadOnlySetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableIReadOnlySetTests.cs
@@ -5,15 +5,15 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.G
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
-[DynamoDBMarshaller(EntityType = typeof(Container<SortedSet<string>>))]
-public partial class SortedSetTests() : NoneNullableElementAsserter<SortedSet<string>, string>(Strings(), x => new SortedSet<string>(x))
+[DynamoDBMarshaller(EntityType = typeof(Container<IReadOnlySet<string?>>))]
+public partial class NullableIReadOnlySetTests() : NullableElementAsserter<IReadOnlySet<string?>, string>(Strings(), x => new HashSet<string?>(x))
 {
-    protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<SortedSet<string>> element)
+    protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<IReadOnlySet<string?>> element)
     {
         return ContainerMarshaller.Marshall(element);
     }
 
-    protected override Container<SortedSet<string>> UnmarshallImplementation(
+    protected override Container<IReadOnlySet<string?>> UnmarshallImplementation(
         Dictionary<string, AttributeValue> attributeValues)
     {
         return ContainerMarshaller.Unmarshall(attributeValues);
@@ -23,6 +23,6 @@ public partial class SortedSetTests() : NoneNullableElementAsserter<SortedSet<st
     public void Unmarshall_Implementation_ShouldBeHashset()
     {
         Arguments().Should().AllSatisfy(x =>
-            ContainerMarshaller.Unmarshall(x.attributeValues).Element.Should().BeOfType<SortedSet<string>>());
+            ContainerMarshaller.Unmarshall(x.attributeValues).Element.Should().BeOfType<HashSet<string?>>());
     }
 }

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableISetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableISetTests.cs
@@ -5,15 +5,15 @@ using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.G
 
 namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
 
-[DynamoDBMarshaller(EntityType = typeof(Container<SortedSet<string>>))]
-public partial class SortedSetTests() : NoneNullableElementAsserter<SortedSet<string>, string>(Strings(), x => new SortedSet<string>(x))
+[DynamoDBMarshaller(EntityType = typeof(Container<ISet<string?>>))]
+public partial class NullableISetTests() : NullableElementAsserter<ISet<string?>, string>(Strings(), x => new HashSet<string?>(x))
 {
-    protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<SortedSet<string>> element)
+    protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<ISet<string?>> element)
     {
         return ContainerMarshaller.Marshall(element);
     }
 
-    protected override Container<SortedSet<string>> UnmarshallImplementation(
+    protected override Container<ISet<string?>> UnmarshallImplementation(
         Dictionary<string, AttributeValue> attributeValues)
     {
         return ContainerMarshaller.Unmarshall(attributeValues);
@@ -23,6 +23,6 @@ public partial class SortedSetTests() : NoneNullableElementAsserter<SortedSet<st
     public void Unmarshall_Implementation_ShouldBeHashset()
     {
         Arguments().Should().AllSatisfy(x =>
-            ContainerMarshaller.Unmarshall(x.attributeValues).Element.Should().BeOfType<SortedSet<string>>());
+            ContainerMarshaller.Unmarshall(x.attributeValues).Element.Should().BeOfType<HashSet<string?>>());
     }
 }

--- a/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableSortedSetTests.cs
+++ b/tests/DynamoDBGenerator.SourceGenerator.Tests/DynamoDBDocumentTests/Marshaller/Generics/Sets/NullableSortedSetTests.cs
@@ -1,0 +1,21 @@
+using Amazon.DynamoDBv2.Model;
+using DynamoDBGenerator.Attributes;
+using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Asserters;
+using DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets.Asserters;
+
+namespace DynamoDBGenerator.SourceGenerator.Tests.DynamoDBDocumentTests.Marshaller.Generics.Sets;
+
+[DynamoDBMarshaller(EntityType = typeof(Container<SortedSet<string?>>))]
+public partial class NullableSortedSetTests() : NullableElementAsserter<SortedSet<string?>, string>(Strings(), x => new SortedSet<string?>(x))
+{
+    protected override Container<SortedSet<string?>> UnmarshallImplementation(
+        Dictionary<string, AttributeValue> attributeValues)
+    {
+        return ContainerMarshaller.Unmarshall(attributeValues);
+    }
+
+    protected override Dictionary<string, AttributeValue> MarshallImplementation(Container<SortedSet<string?>> element)
+    {
+        return ContainerMarshaller.Marshall(element);
+    }
+}


### PR DESCRIPTION
Resolves the issue reported in #91 and adds tests to avoid this reoccurring. 