### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
       - "**"
+permissions:
+  contents: read
+  packages: write
 env:
   VERSION: 0.0.0
 


### PR DESCRIPTION
Potential fix for [https://github.com/inputfalken/DynamoDB.SourceGenerator/security/code-scanning/1](https://github.com/inputfalken/DynamoDB.SourceGenerator/security/code-scanning/1)

To fix the issue, add a `permissions` block to restrict the `GITHUB_TOKEN` permissions to the least privileges necessary. In this specific workflow, the `contents: read` permission is sufficient for most operations, and `packages: write` is required for publishing NuGet packages. These permissions should be added at the workflow level or the job level. 

The changes should be made at the root level of the YAML file to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
